### PR TITLE
switch to standard requires

### DIFF
--- a/lib/appoptics/metrics.rb
+++ b/lib/appoptics/metrics.rb
@@ -1,20 +1,17 @@
-$:.unshift(File.dirname(__FILE__)) unless
-  $:.include?(File.dirname(__FILE__)) || $:.include?(File.expand_path(File.dirname(__FILE__)))
-
 require 'base64'
 require 'forwardable'
 
-require 'metrics/aggregator'
-require 'metrics/annotator'
-require 'metrics/client'
-require 'metrics/collection'
-require 'metrics/connection'
-require 'metrics/errors'
-require 'metrics/persistence'
-require 'metrics/queue'
-require 'metrics/smart_json'
-require 'metrics/util'
-require 'metrics/version'
+require 'appoptics/metrics/aggregator'
+require 'appoptics/metrics/annotator'
+require 'appoptics/metrics/client'
+require 'appoptics/metrics/collection'
+require 'appoptics/metrics/connection'
+require 'appoptics/metrics/errors'
+require 'appoptics/metrics/persistence'
+require 'appoptics/metrics/queue'
+require 'appoptics/metrics/smart_json'
+require 'appoptics/metrics/util'
+require 'appoptics/metrics/version'
 
 module AppOptics
 

--- a/lib/appoptics/metrics/aggregator.rb
+++ b/lib/appoptics/metrics/aggregator.rb
@@ -1,5 +1,5 @@
 require 'aggregate'
-require 'metrics/processor'
+require 'appoptics/metrics/processor'
 
 module AppOptics
   module Metrics

--- a/lib/appoptics/metrics/connection.rb
+++ b/lib/appoptics/metrics/connection.rb
@@ -1,8 +1,8 @@
 require 'faraday'
-require 'metrics/middleware/count_requests'
-require 'metrics/middleware/expects_status'
-require 'metrics/middleware/request_body'
-require 'metrics/middleware/retry'
+require 'appoptics/metrics/middleware/count_requests'
+require 'appoptics/metrics/middleware/expects_status'
+require 'appoptics/metrics/middleware/request_body'
+require 'appoptics/metrics/middleware/retry'
 
 module AppOptics
   module Metrics

--- a/lib/appoptics/metrics/persistence.rb
+++ b/lib/appoptics/metrics/persistence.rb
@@ -1,2 +1,2 @@
-require 'metrics/persistence/direct'
-require 'metrics/persistence/test'
+require 'appoptics/metrics/persistence/direct'
+require 'appoptics/metrics/persistence/test'

--- a/lib/appoptics/metrics/queue.rb
+++ b/lib/appoptics/metrics/queue.rb
@@ -1,4 +1,4 @@
-require 'metrics/processor'
+require 'appoptics/metrics/processor'
 
 module AppOptics
   module Metrics


### PR DESCRIPTION
Rather than adding a path to the load path, use standard require format qualified with `appoptics/`. This prevents conflicts with the Librato metrics gem in projects that use both.

Unit tests pass; per discussion with @gmckeever, there are other issues in the integration tests, so I didn't address those.