### PR TITLE
add custom headers

### DIFF
--- a/lib/appoptics/metrics.rb
+++ b/lib/appoptics/metrics.rb
@@ -78,7 +78,7 @@ module AppOptics
                     :get_snapshot, :get_source, :metrics,
                     :persistence, :persistence=, :persister, :proxy, :proxy=,
                     :sources, :submit, :update_metric, :update_metrics,
-                    :update_source
+                    :update_source, :set_custom_headers
 
     # The AppOptics::Metrics::Client being used by module-level
     # access.

--- a/lib/appoptics/metrics.rb
+++ b/lib/appoptics/metrics.rb
@@ -78,7 +78,7 @@ module AppOptics
                     :get_snapshot, :get_source, :metrics,
                     :persistence, :persistence=, :persister, :proxy, :proxy=,
                     :sources, :submit, :update_metric, :update_metrics,
-                    :update_source, :set_custom_headers
+                    :update_source, :custom_headers=
 
     # The AppOptics::Metrics::Client being used by module-level
     # access.

--- a/lib/appoptics/metrics/client.rb
+++ b/lib/appoptics/metrics/client.rb
@@ -7,7 +7,7 @@ module AppOptics
       def_delegator :annotator, :add, :annotate
 
       attr_accessor :api_key, :proxy
-      attr_reader :custom_headers
+      attr_accessor :custom_headers
 
       # @example Have the gem build your identifier string
       #   AppOptics::Metrics.agent_identifier 'flintstone', '0.5', 'fred'
@@ -46,10 +46,6 @@ module AppOptics
       #
       def api_endpoint=(endpoint)
         @api_endpoint = endpoint
-      end
-      
-      def custom_headers=(headers)
-        @custom_headers = headers
       end
 
       # Authenticate for direct persistence

--- a/lib/appoptics/metrics/client.rb
+++ b/lib/appoptics/metrics/client.rb
@@ -7,6 +7,7 @@ module AppOptics
       def_delegator :annotator, :add, :annotate
 
       attr_accessor :api_key, :proxy
+      attr_reader :custom_headers
 
       # @example Have the gem build your identifier string
       #   AppOptics::Metrics.agent_identifier 'flintstone', '0.5', 'fred'
@@ -45,6 +46,10 @@ module AppOptics
       #
       def api_endpoint=(endpoint)
         @api_endpoint = endpoint
+      end
+      
+      def set_custom_headers(headers)
+        @custom_headers = headers
       end
 
       # Authenticate for direct persistence

--- a/lib/appoptics/metrics/client.rb
+++ b/lib/appoptics/metrics/client.rb
@@ -48,7 +48,7 @@ module AppOptics
         @api_endpoint = endpoint
       end
       
-      def set_custom_headers(headers)
+      def custom_headers=(headers)
         @custom_headers = headers
       end
 

--- a/lib/appoptics/metrics/connection.rb
+++ b/lib/appoptics/metrics/connection.rb
@@ -44,7 +44,19 @@ module AppOptics
         end.tap do |transport|
           transport.headers[:user_agent] = user_agent
           transport.headers[:content_type] = 'application/json'
+          merge_custom_headers(transport)
           transport.basic_auth @client.api_key, nil
+        end
+      end
+      
+      def custom_headers
+        @client.custom_headers
+      end
+      
+      def merge_custom_headers(transport)
+        return if custom_headers.nil?
+        custom_headers.each do |key, val|
+          transport.headers[key] = val
         end
       end
 

--- a/spec/unit/metrics/client_spec.rb
+++ b/spec/unit/metrics/client_spec.rb
@@ -120,6 +120,14 @@ module AppOptics
         end
       end
 
+      describe "#set_custom_headers" do
+        it "adds custom headers" do
+          headers = {"Foo-Header" => "bar"}
+          subject.set_custom_headers(headers)
+          expect(subject.custom_headers).to eq(headers)
+        end
+      end
+
     end
 
   end

--- a/spec/unit/metrics/client_spec.rb
+++ b/spec/unit/metrics/client_spec.rb
@@ -123,7 +123,7 @@ module AppOptics
       describe "#set_custom_headers" do
         it "adds custom headers" do
           headers = {"Foo-Header" => "bar"}
-          subject.set_custom_headers(headers)
+          subject.custom_headers = headers
           expect(subject.custom_headers).to eq(headers)
         end
       end

--- a/spec/unit/metrics/connection_spec.rb
+++ b/spec/unit/metrics/connection_spec.rb
@@ -63,6 +63,14 @@ module AppOptics
           client
         end
 
+        context "with custom headers" do
+          it "merges custom headers into transport" do
+            headers = {"Foo-Header" => "bar"}
+            client.custom_headers = headers
+            expect(client.connection.transport.headers["Foo-Header"]).to eq("bar")
+          end
+        end
+
         context "with 400 class errors" do
           it "does not retry" do
             Middleware::CountRequests.reset

--- a/spec/unit/metrics_spec.rb
+++ b/spec/unit/metrics_spec.rb
@@ -58,6 +58,14 @@ module AppOptics
      end
    end
 
+   describe "#custom_headers" do
+     it "saves custom headers" do
+       headers = {'Some-Custom-Header' => 'abcdef1234' }
+       expect { AppOptics::Metrics.set_custom_headers(headers) }.not_to raise_error
+       expect(AppOptics::Metrics.client.custom_headers).to eq(headers)
+     end
+   end
+
   end
 
 end

--- a/spec/unit/metrics_spec.rb
+++ b/spec/unit/metrics_spec.rb
@@ -61,7 +61,7 @@ module AppOptics
    describe "#custom_headers" do
      it "saves custom headers" do
        headers = {'Some-Custom-Header' => 'abcdef1234' }
-       expect { AppOptics::Metrics.set_custom_headers(headers) }.not_to raise_error
+       expect { AppOptics::Metrics.custom_headers = headers }.not_to raise_error
        expect(AppOptics::Metrics.client.custom_headers).to eq(headers)
      end
    end


### PR DESCRIPTION
Custom headers can be added before submit like that:
AppOptics::Metrics.custom_headers = {'Some-Custom-Header': 'abcdef1234' }